### PR TITLE
Debug kapt illegal access error

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,11 +32,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
     buildFeatures {
         compose = true
@@ -48,6 +48,15 @@ android {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
+    }
+}
+
+// Add kapt configuration to fix JDK compatibility issues
+kapt {
+    correctErrorTypes = true
+    javacOptions {
+        // Increase the max count of errors from annotation processors.
+        option("-Xmaxerrs", 500)
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,13 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 \
+  --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.4.0-beta02"
-kotlin = "1.9.0"
+kotlin = "1.9.22"
 coreKtx = "1.12.0"
 junit = "4.13.2"
 junitVersion = "1.1.5"


### PR DESCRIPTION
Resolve KAPT `IllegalAccessError` by configuring JDK module exports and updating Java/Kotlin versions.

The `IllegalAccessError` occurs because KAPT needs access to internal Java compiler APIs, which are restricted by default in newer JDK versions (16+). This PR adds the necessary JVM arguments to allow this access and updates Java/Kotlin compatibility for better alignment.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-bccf0709-5ad8-4277-a276-c689fc3a2604) · [Cursor](https://cursor.com/background-agent?bcId=bc-bccf0709-5ad8-4277-a276-c689fc3a2604)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)